### PR TITLE
Update enlarge icon to SVG

### DIFF
--- a/script.js
+++ b/script.js
@@ -214,9 +214,17 @@ document.addEventListener('DOMContentLoaded', () => {
             if (wrapper && wrapper.classList.contains('textarea-wrapper')) {
                 const icon = document.createElement('span');
                 icon.classList.add('enlarge-icon');
-                icon.innerHTML = '&#x26F6;'; // Unicode for expand arrows (may need adjustment or SVG) - Using a different one: ⛶ (SQUARE WITH DIAGONAL CROSSHATCH FILL) or ✥ (MALTESE CROSS) - let's try ↗
-                icon.innerHTML = '&#x2197;'; // North East Arrow (simple expand)
+                // Use the provided SVG string
+                icon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width: 100%; height: 100%;">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+                                  </svg>`;
                 icon.title = 'Enlarge editor'; // Tooltip
+
+                // Ensure the SVG inside the span is not focusable itself, the span is the target.
+                const svgElement = icon.querySelector('svg');
+                if (svgElement) {
+                    svgElement.setAttribute('focusable', 'false');
+                }
 
                 icon.addEventListener('click', () => {
                     currentEditingTextarea = textarea;

--- a/style.css
+++ b/style.css
@@ -69,14 +69,14 @@ h1 {
     position: absolute;
     top: 8px;
     right: 8px;
-    width: 20px;
-    height: 20px;
+    width: 20px;  /*Desired width of the icon container */
+    height: 20px; /* Desired height of the icon container */
     cursor: pointer;
-    font-size: 16px; /* Adjust as needed */
-    line-height: 20px;
-    text-align: center;
-    color: #555;
-    /* background-color: #f0f0f0; For testing visibility */
+    color: #555; /* SVG will inherit this color for its 'currentColor' stroke */
+    display: inline-flex; /* Helps to align SVG properly if it's not block */
+    align-items: center;
+    justify-content: center;
+    /* background-color: #f0f0f0; /* For testing visibility */
     /* border: 1px solid #ccc; For testing visibility */
     z-index: 1; /* Ensure icon is above textarea's potential content */
     user-select: none;


### PR DESCRIPTION
- Modify script.js to use the provided SVG for the textarea enlarge icon.
- Adjust style.css for .enlarge-icon to correctly display and size the SVG.